### PR TITLE
add support for backward compativility for java 1.8 runtime

### DIFF
--- a/src/main/java/tlschannel/ServerTlsChannel.java
+++ b/src/main/java/tlschannel/ServerTlsChannel.java
@@ -1,6 +1,7 @@
 package tlschannel;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.Channel;
@@ -373,13 +374,13 @@ public class ServerTlsChannel implements TlsChannel {
     inEncrypted.prepare();
     try {
       int recordHeaderSize = readRecordHeaderSize();
-      while (inEncrypted.buffer.position() < recordHeaderSize) {
+      while (((Buffer)inEncrypted.buffer).position() < recordHeaderSize) {
         if (!inEncrypted.buffer.hasRemaining()) {
           inEncrypted.enlarge();
         }
         TlsChannelImpl.readFromChannel(underlying, inEncrypted.buffer); // IO block
       }
-      inEncrypted.buffer.flip();
+      ((Buffer)inEncrypted.buffer).flip();
       Map<Integer, SNIServerName> serverNames = TlsExplorer.explore(inEncrypted.buffer);
       inEncrypted.buffer.compact();
       SNIServerName hostName = serverNames.get(StandardConstants.SNI_HOST_NAME);
@@ -395,13 +396,13 @@ public class ServerTlsChannel implements TlsChannel {
   }
 
   private int readRecordHeaderSize() throws IOException, EofException {
-    while (inEncrypted.buffer.position() < TlsExplorer.RECORD_HEADER_SIZE) {
+    while (((Buffer)inEncrypted.buffer).position() < TlsExplorer.RECORD_HEADER_SIZE) {
       if (!inEncrypted.buffer.hasRemaining()) {
         throw new IllegalStateException("inEncrypted too small");
       }
       TlsChannelImpl.readFromChannel(underlying, inEncrypted.buffer); // IO block
     }
-    inEncrypted.buffer.flip();
+    ((Buffer)inEncrypted.buffer).flip();
     int recordHeaderSize = TlsExplorer.getRequiredSize(inEncrypted.buffer);
     inEncrypted.buffer.compact();
     return recordHeaderSize;

--- a/src/main/java/tlschannel/impl/BufferHolder.java
+++ b/src/main/java/tlschannel/impl/BufferHolder.java
@@ -1,5 +1,6 @@
 package tlschannel.impl;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -44,7 +45,7 @@ public class BufferHolder {
   }
 
   public boolean release() {
-    if (opportunisticDispose && buffer.position() == 0) {
+    if (opportunisticDispose && ((Buffer)buffer).position() == 0) {
       return dispose();
     } else {
       return false;
@@ -91,7 +92,7 @@ public class BufferHolder {
 
   private void resizeImpl(int newCapacity) {
     ByteBuffer newBuffer = allocator.allocate(newCapacity);
-    buffer.flip();
+    ((Buffer)buffer).flip();
     newBuffer.put(buffer);
     if (plainData) {
       zero();
@@ -120,12 +121,12 @@ public class BufferHolder {
    */
   public void zero() {
     buffer.mark();
-    buffer.position(0);
+    ((Buffer)buffer).position(0);
     buffer.put(zeros, 0, buffer.remaining());
     buffer.reset();
   }
 
   public boolean nullOrEmpty() {
-    return buffer == null || buffer.position() == 0;
+    return buffer == null || ((Buffer)buffer).position() == 0;
   }
 }

--- a/src/main/java/tlschannel/impl/ByteBufferUtil.java
+++ b/src/main/java/tlschannel/impl/ByteBufferUtil.java
@@ -1,5 +1,6 @@
 package tlschannel.impl;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 public class ByteBufferUtil {
@@ -24,8 +25,8 @@ public class ByteBufferUtil {
       return;
     }
     ByteBuffer tmp = src.duplicate();
-    tmp.limit(src.position() + length);
+    tmp.limit(((Buffer)src).position() + length);
     dst.put(tmp);
-    src.position(src.position() + length);
+    ((Buffer)src).position(((Buffer)src).position() + length);
   }
 }

--- a/src/main/java/tlschannel/impl/TlsChannelImpl.java
+++ b/src/main/java/tlschannel/impl/TlsChannelImpl.java
@@ -3,6 +3,7 @@ package tlschannel.impl;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.*;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.ClosedChannelException;
@@ -179,7 +180,7 @@ public class TlsChannelImpl implements ByteChannel {
         throw new ClosedChannelException();
       }
       HandshakeStatus handshakeStatus = engine.getHandshakeStatus();
-      int bytesToReturn = inPlain.nullOrEmpty() ? 0 : inPlain.buffer.position();
+      int bytesToReturn = inPlain.nullOrEmpty() ? 0 : ((Buffer)inPlain.buffer).position();
       while (true) {
         if (bytesToReturn > 0) {
           if (inPlain.nullOrEmpty()) {
@@ -229,7 +230,7 @@ public class TlsChannelImpl implements ByteChannel {
   }
 
   private int transferPendingPlain(ByteBufferSet dstBuffers) {
-    inPlain.buffer.flip(); // will read
+    ((Buffer)inPlain.buffer).flip(); // will read
     int bytes = dstBuffers.putRemaining(inPlain.buffer);
     inPlain.buffer.compact(); // will write
     boolean disposed = inPlain.release();
@@ -280,7 +281,7 @@ public class TlsChannelImpl implements ByteChannel {
   }
 
   private SSLEngineResult callEngineUnwrap(ByteBufferSet dest) throws SSLException {
-    inEncrypted.buffer.flip();
+    ((Buffer)inEncrypted.buffer).flip();
     try {
       SSLEngineResult result =
           engine.unwrap(inEncrypted.buffer, dest.array, dest.offset, dest.length);
@@ -412,10 +413,10 @@ public class TlsChannelImpl implements ByteChannel {
   }
 
   private void writeToChannel() throws IOException {
-    if (outEncrypted.buffer.position() == 0) {
+    if (((Buffer)outEncrypted.buffer).position() == 0) {
       return;
     }
-    outEncrypted.buffer.flip();
+    ((Buffer)outEncrypted.buffer).flip();
     try {
       try {
         writeToChannel(writeChannel, outEncrypted.buffer);

--- a/src/main/java/tlschannel/impl/TlsExplorer.java
+++ b/src/main/java/tlschannel/impl/TlsExplorer.java
@@ -1,5 +1,6 @@
 package tlschannel.impl;
 
+import java.nio.Buffer;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -115,7 +116,7 @@ public final class TlsExplorer {
     // records, but in practice this does not occur.
     if (handshakeLength > recordLength - 4) // 4: handshake header size
     throw new SSLProtocolException("Handshake message spans multiple records");
-    input.limit(handshakeLength + input.position());
+    input.limit(handshakeLength + ((Buffer)input).position());
     return exploreClientHello(input);
   }
 
@@ -238,7 +239,7 @@ public final class TlsExplorer {
   }
 
   private static void ignore(ByteBuffer input, int length) {
-    if (length != 0) input.position(input.position() + length);
+    if (length != 0) ((Buffer)input).position(((Buffer)input).position() + length);
   }
 
   // For some reason, SNIServerName is abstract


### PR DESCRIPTION
Getting the following error in java 1.8
```
java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;
```

As there is an incompatibility between java bytecode generated by 1.9+ compilers and 1.8 runtime, i have added some functionality to be able to run the binary on 1.8 runtime code too. It is a simple cast to basic type, which fixes the method lookup on the older runtime.

See the same issues:
https://github.com/fornwall/jelf/pull/5
eclipse/jetty.project#3244 for explanation.