### PR TITLE
Fix IndexOutOfBoundsException in TlsChannelImpl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ dependencies {
     testImplementation 'org.scalatestplus:scalatestplus-junit_2.13:1.0.0-M2'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'com.typesafe.scala-logging:scala-logging_2.13:3.9.2'
+	
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
+	testImplementation 'io.netty:netty-buffer:4.1.45.Final'
+	testImplementation 'io.netty:netty-handler:4.1.45.Final'
+	testRuntime 'io.netty:netty-tcnative-boringssl-static:2.0.25.Final'
 }
 
 spotless {
@@ -50,6 +55,7 @@ test {
         showStandardStreams = true
         events = ["failed", "skipped", "passed"]
     }
+	useJUnitPlatform()
 }
 
 javadoc {

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,84 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/src/main/java/tlschannel/impl/TlsChannelImpl.java
+++ b/src/main/java/tlschannel/impl/TlsChannelImpl.java
@@ -153,7 +153,8 @@ public class TlsChannelImpl implements ByteChannel {
 
   // handshake wrap() method calls need a buffer to read from, even when they
   // actually do not read anything
-  private final ByteBufferSet dummyOut = new ByteBufferSet(new ByteBuffer[] { ByteBuffer.allocate(1) });
+  private final ByteBufferSet dummyOut =
+      new ByteBufferSet(new ByteBuffer[] {ByteBuffer.allocate(1)});
 
   public Consumer<SSLSession> getSessionInitCallback() {
     return initSessionCallback;

--- a/src/main/java/tlschannel/impl/TlsChannelImpl.java
+++ b/src/main/java/tlschannel/impl/TlsChannelImpl.java
@@ -153,7 +153,7 @@ public class TlsChannelImpl implements ByteChannel {
 
   // handshake wrap() method calls need a buffer to read from, even when they
   // actually do not read anything
-  private final ByteBufferSet dummyOut = new ByteBufferSet(new ByteBuffer[] {});
+  private final ByteBufferSet dummyOut = new ByteBufferSet(new ByteBuffer[] { ByteBuffer.allocate(1) });
 
   public Consumer<SSLSession> getSessionInitCallback() {
     return initSessionCallback;

--- a/src/test/java/NettySSLEngineTests.java
+++ b/src/test/java/NettySSLEngineTests.java
@@ -1,0 +1,111 @@
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
+import org.junit.jupiter.api.Test;
+import tlschannel.ClientTlsChannel;
+import tlschannel.HeapBufferAllocator;
+import tlschannel.NeedsWriteException;
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.security.KeyStore;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+public class NettySSLEngineTests {
+
+    @Test
+    public void nettySSLEngineInitializationTest() throws IOException {
+        SslContext ctx = SslContextBuilder.forClient()
+                .sslProvider(SslProvider.OPENSSL)
+                .trustManager(dummyTrustManagerFacotory)
+                .protocols("TLSv1.3")
+                .build();
+        SSLEngine sslEngine = ctx.newEngine(ByteBufAllocator.DEFAULT, "test", 0);
+
+        ClientTlsChannel chan = ClientTlsChannel.newBuilder(new DummyByteChannel(), sslEngine)
+                .withEncryptedBufferAllocator(new HeapBufferAllocator())
+                .build();
+
+        try {
+            chan.handshake();
+        }
+        catch (NeedsWriteException es) {
+            // test passed, expected exception
+        }
+    }
+
+    private static class DummyByteChannel implements ByteChannel {
+        @Override
+        public boolean isOpen() {
+            return false;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            return 0;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            return 0;
+        }
+    }
+
+    private TrustManagerFactory dummyTrustManagerFacotory = new SimpleTrustManagerFactory() {
+        private TrustManager[] trustManagers = new TrustManager[] {new DummyTrustManager()};
+
+        @Override
+        protected void engineInit(KeyStore keyStore) throws Exception {
+        }
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters managerFactoryParameters) throws Exception {
+        }
+
+        @Override
+        protected TrustManager[] engineGetTrustManagers() {
+            return trustManagers;
+        }
+    };
+
+    private static class DummyTrustManager extends X509ExtendedTrustManager {
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
+        }
+    }
+}


### PR DESCRIPTION
This change fixes an IndexOutOfBoundsException that is thrown in my use case in the first handshake in the TlsChannelImpl: 

java.lang.IndexOutOfBoundsException: offset: 0, length: 0 (expected: offset <= offset + length <= srcs.length (0))

	at io.netty.handler.ssl.ReferenceCountedOpenSslEngine.wrap(ReferenceCountedOpenSslEngine.java:688)
	at tlschannel.impl.TlsChannelImpl.callEngineWrap(TlsChannelImpl.java:388)
	at tlschannel.impl.TlsChannelImpl.wrapLoop(TlsChannelImpl.java:370)
	at tlschannel.impl.TlsChannelImpl.handshakeLoop(TlsChannelImpl.java:539)
	at tlschannel.impl.TlsChannelImpl.handshake(TlsChannelImpl.java:519)
	at tlschannel.impl.TlsChannelImpl.doHandshake(TlsChannelImpl.java:494)
	at tlschannel.impl.TlsChannelImpl.handshake(TlsChannelImpl.java:480)
	at tlschannel.ClientTlsChannel.handshake(ClientTlsChannel.java:184)

