### PR TITLE
Ensure key is not null before cancelling it

### DIFF
--- a/src/main/java/tlschannel/async/AsynchronousTlsChannelGroup.java
+++ b/src/main/java/tlschannel/async/AsynchronousTlsChannelGroup.java
@@ -86,7 +86,7 @@ public class AsynchronousTlsChannelGroup {
     public void close() {
       doCancelRead(this, null);
       doCancelWrite(this, null);
-      key.cancel();
+      if (key != null) key.cancel();
       currentRegistrations.getAndDecrement();
       /*
        * Actual de-registration from the selector will happen asynchronously.


### PR DESCRIPTION
There is a race condition between the loop setting the key and close() being called.  If the key has not been set it can cause a NPE.