### PR TITLE
On RegisteredSocket.close handle existing socket operations

### DIFF
--- a/src/main/java/tlschannel/async/AsynchronousTlsChannelGroup.java
+++ b/src/main/java/tlschannel/async/AsynchronousTlsChannelGroup.java
@@ -11,6 +11,7 @@ import java.nio.channels.ShutdownChannelGroupException;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.WritePendingException;
 import java.util.Iterator;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -224,6 +225,9 @@ public class AsynchronousTlsChannelGroup {
     try {
       // a null op means cancel any operation
       if (op != null && socket.readOperation == op || op == null && socket.readOperation != null) {
+        if (op == null) {
+          socket.readOperation.onFailure.accept(new CancellationException());
+        }
         socket.readOperation = null;
         cancelledReads.increment();
         currentReads.decrement();
@@ -242,6 +246,9 @@ public class AsynchronousTlsChannelGroup {
       // a null op means cancel any operation
       if (op != null && socket.writeOperation == op
           || op == null && socket.writeOperation != null) {
+        if (op == null) {
+          socket.writeOperation.onFailure.accept(new CancellationException());
+        }
         socket.writeOperation = null;
         cancelledWrites.increment();
         currentWrites.decrement();

--- a/src/test/scala/tlschannel/async/AsyncCloseTest.scala
+++ b/src/test/scala/tlschannel/async/AsyncCloseTest.scala
@@ -1,0 +1,66 @@
+package tlschannel.async
+
+import java.nio.ByteBuffer
+import java.util.concurrent.{CancellationException, TimeUnit}
+
+import org.junit.runner.RunWith
+import org.scalatest.Assertions
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+import tlschannel.helpers.{SocketPairFactory, SslContextFactory}
+
+@RunWith(classOf[JUnitRunner])
+class AsyncCloseTest extends AnyFunSuite with AsyncTestBase with Assertions {
+
+  val sslContextFactory = new SslContextFactory
+  val factory = new SocketPairFactory(sslContextFactory.defaultContext)
+
+  val bufferSize = 10000
+
+  test("should throw an AsynchronousCloseException when closing the group while reading") {
+    val channelGroup = new AsynchronousTlsChannelGroup()
+    val socketPair = factory.async(null, channelGroup, runTasks = true)
+
+    val readBuffer = ByteBuffer.allocate(bufferSize)
+    val readFuture = socketPair.server.external.read(readBuffer)
+    socketPair.server.external.close()
+    socketPair.client.external.close()
+
+    assertThrows[CancellationException] {
+      readFuture.get(1000, TimeUnit.MILLISECONDS)
+    }
+
+    shutdownChannelGroup(channelGroup)
+    assertChannelGroupConsistency(channelGroup)
+
+    assert(channelGroup.getCancelledReadCount == 1)
+    assert(channelGroup.getFailedReadCount == 0)
+    assert(channelGroup.getSuccessfulReadCount == 0)
+
+    printChannelGroupStatus(channelGroup)
+  }
+
+  test("should throw an AsynchronousCloseException when closing the group while writing") {
+    val channelGroup = new AsynchronousTlsChannelGroup()
+    val socketPair = factory.async(null, channelGroup, runTasks = true)
+
+    val writeBuffer = ByteBuffer.allocate(bufferSize)
+    val writeFuture = socketPair.server.external.write(writeBuffer)
+    socketPair.server.external.close()
+    socketPair.client.external.close()
+
+    assertThrows[CancellationException] {
+      writeFuture.get(1000, TimeUnit.MILLISECONDS)
+    }
+
+    shutdownChannelGroup(channelGroup)
+    assertChannelGroupConsistency(channelGroup)
+
+    assert(channelGroup.getCancelledWriteCount == 1)
+    assert(channelGroup.getFailedWriteCount == 0)
+    assert(channelGroup.getSuccessfulWriteCount == 0)
+
+    printChannelGroupStatus(channelGroup)
+  }
+
+}

--- a/src/test/scala/tlschannel/helpers/SocketPairFactory.scala
+++ b/src/test/scala/tlschannel/helpers/SocketPairFactory.scala
@@ -275,6 +275,15 @@ class SocketPairFactory(
     }
   }
 
+  def async(
+      cipher: Option[String] = None,
+      channelGroup: AsynchronousTlsChannelGroup,
+      runTasks: Boolean,
+      waitForCloseConfirmation: Boolean = false
+  ): AsyncSocketPair = {
+    asyncN(cipher, channelGroup, 1, runTasks, waitForCloseConfirmation).head
+  }
+
   def asyncN(
       cipher: Option[String] = None,
       channelGroup: AsynchronousTlsChannelGroup,


### PR DESCRIPTION
Ensure any existing socket operations are notified as failed
due to close being called on the socket.