### PR TITLE
Fix race condition when closing async sockets right after creation.

### DIFF
--- a/src/test/scala/tlschannel/async/AsyncCloseTest.scala
+++ b/src/test/scala/tlschannel/async/AsyncCloseTest.scala
@@ -52,6 +52,7 @@ class AsyncCloseTest extends AnyFunSuite with AsyncTestBase with Assertions {
       assert(channelGroup.getSuccessfulReadCount == 0)
 
       printChannelGroupStatus(channelGroup)
+      channelGroup.shutdown()
     }
   }
 

--- a/src/test/scala/tlschannel/async/AsyncQuickCloseTest.scala
+++ b/src/test/scala/tlschannel/async/AsyncQuickCloseTest.scala
@@ -1,0 +1,29 @@
+package tlschannel.async
+
+import org.scalatest.Assertions
+import org.scalatest.funsuite.AnyFunSuite
+import tlschannel.helpers.{SocketPairFactory, SslContextFactory}
+
+class AsyncQuickCloseTest extends AnyFunSuite with Assertions {
+
+  val sslContextFactory = new SslContextFactory
+  val factory = new SocketPairFactory(sslContextFactory.defaultContext)
+
+  /*
+   * Closing sockets registered in an asynchronous channel group is inherently racy, using repetitions to try to catch
+   * most races.
+   */
+  val repetitions = 1000
+
+  // see https://github.com/marianobarrios/tls-channel/issues/34
+  test("should not cause the selector thread to die") {
+    val channelGroup = new AsynchronousTlsChannelGroup()
+    for (_ <- 1 to repetitions) {
+      val socketPair = factory.async(null, channelGroup, runTasks = true)
+      socketPair.server.external.close()
+      assert(channelGroup.isAlive)
+    }
+    channelGroup.shutdown()
+  }
+
+}


### PR DESCRIPTION
See: https://github.com/marianobarrios/tls-channel/issues/34