### PR TITLE
use JOSM Utils implementation to allow versions with hypens (i.e. 17-ea)

### DIFF
--- a/src/main/java/tlschannel/util/Util.java
+++ b/src/main/java/tlschannel/util/Util.java
@@ -31,13 +31,16 @@ public class Util {
   public static int getJavaMajorVersion() {
     String version = System.getProperty("java.version");
     if (version.startsWith("1.")) {
-      version = version.substring(2, 3);
-    } else {
-      int dot = version.indexOf(".");
-      if (dot != -1) {
-        version = version.substring(0, dot);
-      }
+      version = version.substring(2);
     }
-    return Integer.parseInt(version);
+    // Allow these formats:
+    // 1.8.0_72-ea
+    // 9-ea
+    // 9
+    // 9.0.1
+    int dotPos = version.indexOf('.');
+    int dashPos = version.indexOf('-');
+    return Integer.parseInt(version.substring(0,
+            dotPos > -1 ? dotPos : dashPos > -1 ? dashPos : 1));
   }
 }

--- a/src/main/java/tlschannel/util/Util.java
+++ b/src/main/java/tlschannel/util/Util.java
@@ -40,7 +40,7 @@ public class Util {
     // 9.0.1
     int dotPos = version.indexOf('.');
     int dashPos = version.indexOf('-');
-    return Integer.parseInt(version.substring(0,
-            dotPos > -1 ? dotPos : dashPos > -1 ? dashPos : 1));
+    return Integer.parseInt(
+        version.substring(0, dotPos > -1 ? dotPos : dashPos > -1 ? dashPos : 1));
   }
 }


### PR DESCRIPTION
While running with openjdk:17-alpine, I received the following exception:
`java.lang.NumberFormatException: For input string: "17-ea"`, coming from tlschannel.util.Util.getJavaMajorVersion(Util.java:41)

The current implementation of parsing the Java version doesn't take dashes into account, such as 17-ea. 
JOSM has an alternative method that does work with java versions including hyphens:
https://github.com/JOSM/josm/blob/master/src/org/openstreetmap/josm/tools/Utils.java
