### PR TITLE
Fix `Util.getJavaMajorVersion` so that it correctly parses version strings like "17"

### DIFF
--- a/src/main/java/tlschannel/util/Util.java
+++ b/src/main/java/tlschannel/util/Util.java
@@ -38,9 +38,10 @@ public class Util {
     // 9-ea
     // 9
     // 9.0.1
+    // 17
     int dotPos = version.indexOf('.');
     int dashPos = version.indexOf('-');
     return Integer.parseInt(
-        version.substring(0, dotPos > -1 ? dotPos : dashPos > -1 ? dashPos : 1));
+        version.substring(0, dotPos > -1 ? dotPos : dashPos > -1 ? dashPos : version.length()));
   }
 }


### PR DESCRIPTION
We [noticed in mongo-java-driver](https://github.com/mongodb/mongo-java-driver/pull/969#discussion_r904474687) that `Util.getJavaMajorVersion` returns 1 if the version string is, for example, "17". This PR suggests a fix.