### PR TITLE
Added automatic module name for modular projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,12 @@ java {
     withJavadocJar()
 }
 
+jar {
+    manifest {
+        attributes  'Automatic-Module-Name': 'tls.channel'
+    }
+}
+
 // see tlschannel.AllocationTest for comment about this
 task allocationTest(type: JavaExec) {
     classpath = sourceSets.test.runtimeClasspath


### PR DESCRIPTION
In order to properly incorporate this library into Java 11+ projects, in particular those using jlink, every jar needs a module name. This PR adds one for tls-channel

Preferably a module-info.java is added to src/main/java, but that can sometimes break compatibility with Java 8--which is why this PR adds the automatic module name instead.