### PR TITLE
Reinstate the interrupt status when hiding `InterruptedException`

### DIFF
--- a/src/main/java/tlschannel/async/AsynchronousTlsChannelGroup.java
+++ b/src/main/java/tlschannel/async/AsynchronousTlsChannelGroup.java
@@ -346,6 +346,7 @@ public class AsynchronousTlsChannelGroup {
         try {
             socket.registered.await();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
We [vendor](https://github.com/mongodb/mongo-java-driver/tree/master/driver-core/src/main/com/mongodb/internal/connection/tlschannel) tls-channel in mongo-java-driver, and found this issue while working on https://jira.mongodb.org/browse/JAVA-4649.

By convention, a method that completes abruptly with `InterruptedException` clears the interrupt status before doing so<sup>1</sup>. Thus, the thrown `InterruptedException` is the only thing conveying information about the fact that the thread detected it has been interrupted. If we then swallow or wrap the `InterruptedException`, we erase that information. Erasing this information at some point may be fine if we own a thread, but if we don't, then we must preserve that information by either throwing `InterruptedException`, which is not always convenient because it's a checked exception, or by reinstating the interrupt status of the thread by calling `Thread.currentThread().interrupt()`.

With structured concurrency https://openjdk.org/jeps/453 now using the thread interruption mechanism for task cancellation, it becomes more important than previously to write code that is responsive to interrupts and does not erase the information about them.

---

<sup>1</sup> I find it weird that this is a conventions, not a requirement, and that the convention is described vaguely in
https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/lang/InterruptedException.html. The convention exists nonetheless, and implementations of the Java SE API follow it.