### PR TITLE
Report data delivered alongside a buffered close_notify in a single read

### DIFF
--- a/src/main/java/tlschannel/TlsChannel.java
+++ b/src/main/java/tlschannel/TlsChannel.java
@@ -125,6 +125,11 @@ public interface TlsChannel extends ByteChannel, GatheringByteChannel, Scatterin
      * NeedsTaskException} will be thrown. In this case the operation should be retried after the task
      * is run.
      *
+     * <p>The end of stream may be detected by the same invocation that returns data, when the peer's
+     * close_notify is already available together with it: in that case the data is returned, the
+     * shutdown is observable immediately via {@link #shutdownReceived()}, and the next invocation
+     * returns <code>-1</code> without any further I/O.
+     *
      * <p>This method may be invoked at any time. If another thread has already initiated a read or
      * handshaking operation upon this channel, however, then an invocation of this method will block
      * until the first operation is complete.

--- a/src/main/java/tlschannel/impl/TlsChannelImpl.java
+++ b/src/main/java/tlschannel/impl/TlsChannelImpl.java
@@ -200,9 +200,9 @@ public class TlsChannelImpl implements ByteChannel {
                     case NOT_HANDSHAKING:
                     case FINISHED:
                         readAndUnwrap();
-                        if (shutdownReceived) {
-                            return -1;
-                        }
+                        // bytesToReturn and shutdownReceived are handled at the top of the loop, in
+                        // that order: a read that produced data and also detected the peer's close
+                        // returns the data, and the next read returns -1
                         break;
                     case NEED_TASK:
                         handleTask();
@@ -593,6 +593,9 @@ public class TlsChannelImpl implements ByteChannel {
                 HandshakeStatus status = engine.getHandshakeStatus();
                 if (result.bytesProduced() > 0) {
                     bytesToReturn = result.bytesProduced();
+                    if (suppliedInPlain != null && inPlain.nullOrEmpty()) {
+                        unwrapBufferedFollowUpRecords();
+                    }
                     return;
                 }
                 if (result.getStatus() == Status.CLOSED) {
@@ -611,6 +614,54 @@ public class TlsChannelImpl implements ByteChannel {
             }
         } finally {
             inEncrypted.release();
+        }
+    }
+
+    /**
+     * Eagerly unwraps records already buffered in inEncrypted (same network segment, separate TLS
+     * records) so a close_notify following the data is reported together with it in a single
+     * read() call. This lets callers that need the end of stream to delimit a response (e.g. HTTP
+     * responses without Content-Length) see the data and the close together. Uses single engine
+     * unwraps rather than unwrapLoop: OVERFLOW and UNDERFLOW consume nothing, so this can never
+     * spill into inPlain.
+     */
+    private void unwrapBufferedFollowUpRecords() {
+        try {
+            // inEncrypted.buffer is in write-mode: position() == bytes of buffered ciphertext
+            while (inEncrypted.buffer.position() > 0 && suppliedInPlain.hasRemaining()) {
+                SSLEngineResult followUp = callEngineUnwrap(suppliedInPlain);
+                // just as in unwrapLoop, data can be produced even in case of overflow
+                bytesToReturn += followUp.bytesProduced();
+                if (followUp.getStatus() == Status.CLOSED) {
+                    shutdownReceived = true;
+                    return;
+                }
+                if (followUp.getStatus() != Status.OK) {
+                    // BUFFER_UNDERFLOW: partial record buffered; BUFFER_OVERFLOW: destination full.
+                    // Neither consumes source bytes from inEncrypted (any produced bytes are already
+                    // counted above) - leave the remaining records for the next read.
+                    return;
+                }
+                if (followUp.bytesConsumed() == 0) {
+                    // defensive guard against a non-conforming engine reporting OK without
+                    // consuming the record, which would otherwise loop forever
+                    return;
+                }
+                HandshakeStatus status = engine.getHandshakeStatus();
+                if (status != HandshakeStatus.NOT_HANDSHAKING) {
+                    // renegotiation, key update, or any other handshake transition: let the main
+                    // loops drive it
+                    return;
+                }
+            }
+        } catch (SSLException e) {
+            /*
+             * The channel was already marked invalid by callEngineUnwrap, so subsequent reads will
+             * fail. Return the data decrypted so far instead of discarding it, mirroring the
+             * behavior without the eager unwrapping, where the failing record would only have been
+             * hit by the next read.
+             */
+            logger.log(Level.FINEST, "swallowing exception unwrapping follow-up records, returning data: {0}", e);
         }
     }
 

--- a/src/test/java/tlschannel/CloseNotifyWithDataTest.java
+++ b/src/test/java/tlschannel/CloseNotifyWithDataTest.java
@@ -1,0 +1,351 @@
+package tlschannel;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.SplittableRandom;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import tlschannel.helpers.SslContextFactory;
+import tlschannel.helpers.TestUtil;
+import tlschannel.util.Util;
+
+/**
+ * Tests the read semantics when application data and a close_notify alert are delivered in the
+ * same network segment (as separate TLS records), as happens when a server responds and
+ * immediately closes the connection. The data and the close should be reported in a single
+ * read() call, so callers that need the end of stream to delimit a response (e.g. HTTP
+ * responses without Content-Length) see them together.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+public class CloseNotifyWithDataTest {
+
+    private final List<String> protocols = Arrays.asList("TLSv1.2", "TLSv1.3");
+
+    @TestFactory
+    public Collection<DynamicTest> testDataAndCloseNotifyFromOneSegmentInOneRead() {
+        return forAllProtocols("testDataAndCloseNotifyFromOneSegmentInOneRead", protocol -> {
+            Channels channels = handshakedChannels(protocol);
+            byte[] payload = randomBytes(300);
+            channels.server.write(ByteBuffer.wrap(payload));
+            channels.server.close();
+
+            // all server bytes (data record + close_notify record) are now buffered on the wire,
+            // simulating delivery in a single TCP segment; destination is larger than the payload
+            // so buffer size is not under test here
+            ByteBuffer dest = ByteBuffer.allocate(1024);
+            assertEquals(payload.length, channels.client.read(dest));
+            assertEquals(payload.length, dest.position());
+            assertTrue(
+                    channels.client.shutdownReceived(),
+                    "close_notify buffered behind the data should be detected in the same read");
+
+            dest.flip();
+            byte[] received = new byte[dest.remaining()];
+            dest.get(received);
+            assertArrayEquals(payload, received);
+
+            assertEquals(-1, channels.client.read(ByteBuffer.allocate(1)));
+
+            // the shutdown can be completed from the reader side without further reads
+            assertTrue(channels.client.shutdown());
+            channels.client.close();
+        });
+    }
+
+    @TestFactory
+    public Collection<DynamicTest> testCloseNotifyInSeparateSegmentIsReportedOnNextRead() {
+        return forAllProtocols("testCloseNotifyInSeparateSegmentIsReportedOnNextRead", protocol -> {
+            Channels channels = handshakedChannels(protocol);
+            byte[] payload = randomBytes(300);
+            channels.server.write(ByteBuffer.wrap(payload));
+
+            // only the data is buffered; the close arrives later, in its own segment;
+            // destination is larger than the payload so buffer size is not under test here
+            ByteBuffer dest = ByteBuffer.allocate(1024);
+            assertEquals(payload.length, channels.client.read(dest));
+            assertFalse(channels.client.shutdownReceived());
+
+            channels.server.close();
+            assertEquals(-1, channels.client.read(dest));
+            assertTrue(channels.client.shutdownReceived());
+            channels.client.close();
+        });
+    }
+
+    @TestFactory
+    public Collection<DynamicTest> testResponseSpanningMultipleRecordsCountsAllBytes() {
+        return forAllProtocols("testResponseSpanningMultipleRecordsCountsAllBytes", protocol -> {
+            Channels channels = handshakedChannels(protocol);
+            // large enough to require several TLS records (max ~16KB plaintext each)
+            byte[] payload = randomBytes(50_000);
+            channels.server.write(ByteBuffer.wrap(payload));
+            channels.server.close();
+
+            // destination is larger than any single TLS record so it never fills up mid-read;
+            // this test verifies byte counts are correct across records, not partial-delivery
+            assertReadsDeliverExactly(channels.client, payload, ByteBuffer.allocate(64 * 1024));
+        });
+    }
+
+    @TestFactory
+    public Collection<DynamicTest> testDestinationFillingUpMidResponse() {
+        return forAllProtocols("testDestinationFillingUpMidResponse", protocol -> {
+            Channels channels = handshakedChannels(protocol);
+            byte[] payload = randomBytes(50_000);
+            channels.server.write(ByteBuffer.wrap(payload));
+            channels.server.close();
+
+            // the destination fits the first TLS record but fills up while further buffered
+            // records remain, so a partial count must be returned
+            assertReadsDeliverExactly(channels.client, payload, ByteBuffer.allocate(20_000));
+        });
+    }
+
+    @TestFactory
+    public Collection<DynamicTest> testDestinationSmallerThanTlsRecord() {
+        return forAllProtocols("testDestinationSmallerThanTlsRecord", protocol -> {
+            Channels channels = handshakedChannels(protocol);
+            byte[] payload = randomBytes(50_000);
+            channels.server.write(ByteBuffer.wrap(payload));
+            channels.server.close();
+
+            // a destination smaller than a single TLS record forces overflow into the channel's
+            // internal plaintext buffer
+            assertReadsDeliverExactly(channels.client, payload, ByteBuffer.allocate(1000));
+        });
+    }
+
+    @TestFactory
+    public Collection<DynamicTest> testCorruptRecordAfterDataStillDeliversData() {
+        return forAllProtocols("testCorruptRecordAfterDataStillDeliversData", protocol -> {
+            // JDK 8's SSLEngine reports malformed records inconsistently across builds (older builds
+            // throw IllegalArgumentException instead of SSLException); the modern semantics this test
+            // asserts are only guaranteed on Java 9+
+            assumeTrue(Util.getJavaMajorVersion() >= 9, "requires Java 9+ SSLEngine error reporting");
+            Channels channels = handshakedChannels(protocol);
+            byte[] payload = randomBytes(300);
+            channels.server.write(ByteBuffer.wrap(payload));
+
+            // append a corrupt TLS record in the same segment as the data: a complete
+            // application-data record whose ciphertext cannot be decrypted
+            byte[] garbage = new byte[37];
+            TestUtil.nextBytes(new SplittableRandom(13), garbage);
+            ByteBuffer corruptRecord = ByteBuffer.allocate(5 + garbage.length);
+            corruptRecord.put((byte) 23); // content type: application data
+            corruptRecord.put((byte) 3).put((byte) 3); // legacy version TLS 1.2
+            corruptRecord.putShort((short) garbage.length);
+            corruptRecord.put(garbage);
+            corruptRecord.flip();
+            channels.serverToClient.add(corruptRecord);
+
+            // the data preceding the corrupt record must still be delivered;
+            // destination is larger than the 300-byte payload so buffer size is not under test here
+            ByteBuffer dest = ByteBuffer.allocate(1024);
+            assertEquals(payload.length, channels.client.read(dest));
+            assertEquals(payload.length, dest.position());
+
+            // ... and the failure surfaces on the next read
+            assertThrows(IOException.class, () -> channels.client.read(dest));
+        });
+    }
+
+    private interface ProtocolTest {
+        void run(String protocol) throws IOException;
+    }
+
+    private Collection<DynamicTest> forAllProtocols(String testName, ProtocolTest test) {
+        List<DynamicTest> tests = new ArrayList<>();
+        for (String protocol : protocols) {
+            tests.add(DynamicTest.dynamicTest(
+                    String.format("%s() - protocol: %s", testName, protocol), () -> test.run(protocol)));
+        }
+        return tests;
+    }
+
+    private static void assertReadsDeliverExactly(TlsChannel client, byte[] payload, ByteBuffer dest)
+            throws IOException {
+        ByteArrayOutputStream received = new ByteArrayOutputStream();
+        while (true) {
+            int positionBeforeRead = dest.position();
+            int bytesRead = client.read(dest);
+            if (bytesRead == -1) {
+                break;
+            }
+            assertEquals(
+                    positionBeforeRead + bytesRead,
+                    dest.position(),
+                    "read() must report exactly the number of bytes transferred into the destination");
+            dest.flip();
+            byte[] chunk = new byte[dest.remaining()];
+            dest.get(chunk);
+            received.write(chunk, 0, chunk.length);
+            dest.clear();
+        }
+        assertArrayEquals(payload, received.toByteArray());
+        assertTrue(client.shutdownReceived());
+        client.close();
+    }
+
+    private static final class Channels {
+        final TlsChannel client;
+        final TlsChannel server;
+        final Wire serverToClient;
+
+        Channels(TlsChannel client, TlsChannel server, Wire serverToClient) {
+            this.client = client;
+            this.server = server;
+            this.serverToClient = serverToClient;
+        }
+    }
+
+    private static Channels handshakedChannels(String protocol) throws IOException {
+        assumeProtocolSupported(protocol);
+        SSLContext sslContext = new SslContextFactory(protocol).defaultContext();
+        Wire clientToServer = new Wire();
+        Wire serverToClient = new Wire();
+
+        SSLEngine clientEngine = sslContext.createSSLEngine();
+        clientEngine.setUseClientMode(true);
+        clientEngine.setEnabledProtocols(new String[] {protocol});
+        TlsChannel client = ClientTlsChannel.newBuilder(new WireChannel(serverToClient, clientToServer), clientEngine)
+                .build();
+        TlsChannel server = ServerTlsChannel.newBuilder(new WireChannel(clientToServer, serverToClient), sslContext)
+                .build();
+
+        pumpHandshake(client, server);
+        return new Channels(client, server, serverToClient);
+    }
+
+    private static void assumeProtocolSupported(String protocol) {
+        try {
+            // older JDK 8 builds do not support TLSv1.3 at all
+            assumeTrue(
+                    Arrays.asList(SSLContext.getDefault().getSupportedSSLParameters().getProtocols())
+                            .contains(protocol),
+                    protocol + " is not supported by this JVM");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void pumpHandshake(TlsChannel client, TlsChannel server) throws IOException {
+        boolean clientDone = false;
+        boolean serverDone = false;
+        int rounds = 0;
+        while (!(clientDone && serverDone)) {
+            assertTrue(rounds++ < 100, "handshake did not complete");
+            // only NeedsReadException can occur: WireChannel accepts all writes, and tasks run
+            // inline by default, so NeedsWriteException/NeedsTaskException are impossible
+            if (!clientDone) {
+                try {
+                    client.handshake();
+                    clientDone = true;
+                } catch (NeedsReadException e) {
+                    // waiting for server bytes
+                }
+            }
+            if (!serverDone) {
+                try {
+                    server.handshake();
+                    serverDone = true;
+                } catch (NeedsReadException e) {
+                    // waiting for client bytes
+                }
+            }
+        }
+    }
+
+    private static byte[] randomBytes(int size) {
+        byte[] bytes = new byte[size];
+        TestUtil.nextBytes(new SplittableRandom(42), bytes);
+        return bytes;
+    }
+
+    /**
+     * A one-directional, in-memory byte stream. Reads return 0 when no bytes are buffered
+     * (non-blocking semantics) and -1 once closed and drained. Because all written bytes are
+     * available at once, it deterministically simulates records arriving in a single segment.
+     */
+    private static final class Wire {
+        private final Deque<ByteBuffer> chunks = new ArrayDeque<>();
+        private volatile boolean closed;
+
+        void add(ByteBuffer src) {
+            byte[] copy = new byte[src.remaining()];
+            src.get(copy);
+            chunks.add(ByteBuffer.wrap(copy));
+        }
+
+        int drainTo(ByteBuffer dst) {
+            if (chunks.isEmpty()) {
+                return closed ? -1 : 0;
+            }
+            int transferred = 0;
+            while (dst.hasRemaining() && !chunks.isEmpty()) {
+                ByteBuffer head = chunks.peek();
+                int count = Math.min(dst.remaining(), head.remaining());
+                int oldLimit = head.limit();
+                head.limit(head.position() + count);
+                dst.put(head);
+                head.limit(oldLimit);
+                transferred += count;
+                if (!head.hasRemaining()) {
+                    chunks.poll();
+                }
+            }
+            return transferred;
+        }
+    }
+
+    private static final class WireChannel implements ByteChannel {
+        private final Wire in;
+        private final Wire out;
+
+        WireChannel(Wire in, Wire out) {
+            this.in = in;
+            this.out = out;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) {
+            return in.drainTo(dst);
+        }
+
+        @Override
+        public int write(ByteBuffer src) {
+            int count = src.remaining();
+            out.add(src);
+            return count;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return true;
+        }
+
+        @Override
+        public void close() {
+            out.closed = true;
+        }
+    }
+}


### PR DESCRIPTION
When a peer sends a response and immediately closes the connection, the data and the close_notify often arrive in the same network segment. Previously the first read() returned the data but the close was only discovered by a second read() call. Now the same read() returns the data with the shutdown already observable via shutdownReceived(), and the next read() returns -1 without any further I/O. 

This lets callers that rely on the end of stream to delimit a response (for example HTTP responses without a Content-Length header) complete in a single exchange.

Details
-------

This accommodates legal peer behaviour rather than working around a broken one. Sending application data followed immediately by a close_notify is the orderly TLS shutdown sequence
(https://www.rfc-editor.org/rfc/rfc8446#section-6.1 for TLS 1.3, https://www.rfc-editor.org/rfc/rfc5246#section-7.2.1 for TLS 1.2), and delimiting a response by closing the connection is itself valid in close-delimited protocols (e.g.
https://www.rfc-editor.org/rfc/rfc9112#section-6.3 for HTTP/1.1).

The change does not alter what data is delivered or weaken any TLS guarantee: the close_notify is still authenticated and processed by SSLEngine exactly as before, and truncation detection is unchanged. Only the timing of surfacing already-received, already-decrypted information changes. This matches the underlying transport's semantics: when data and a FIN arrive together on a plain socket, a read returns the data and end-of-stream is observable immediately afterwards without further I/O.

After a read produces data, any records already buffered are eagerly unwrapped, folding produced bytes into the returned count and registering a close_notify. The eager unwrapping uses single engine unwraps rather than unwrapLoop: BUFFER_OVERFLOW and BUFFER_UNDERFLOW consume nothing, so it can never spill into the internal plain buffer, and it stops at any handshake transition so renegotiation stays with the main loops. If a buffered record turns out to be corrupt, the data decrypted before it is still returned and the failure surfaces on the next read, matching the previous two-read sequencing.

The inline -1 return after readAndUnwrap() is removed so the loop's existing ordering (return produced bytes first, report -1 on the next call) applies.

Covered by CloseNotifyWithDataTest using deterministic in-memory channels over TLSv1.2 and TLSv1.3: data + close_notify in one segment, close in a separate segment, responses spanning multiple TLS records, destination buffers smaller than a record or filling up mid-response, and a corrupt record following the data.